### PR TITLE
Pass arguments through theme_datacamp to theme_light

### DIFF
--- a/R/theme_datacamp.R
+++ b/R/theme_datacamp.R
@@ -34,6 +34,10 @@ dc_pal <- function(name = c("accents", "greys", "accents_light"), named = FALSE)
 #'
 #' @export
 #' @import ggplot2
+#'
+#' @param ... Extra arguments (eg base_size) to pass to theme_light, which is
+#' the theme that theme_datacamp is built off of. For example
+#'
 #' @examples
 #' library(ggplot2)
 #' ggplot(mtcars, aes(x = mpg, y = wt, color = as.factor(vs))) +


### PR DESCRIPTION
This enables you to set `base_size` (and probably other stuff as well), through to `theme_light`. As far as I can tell you can't pass `base_size` to `theme` and add it to `theme_datacamp` that way. Please correct me if I'm wrong, @ramnathv!