### PR TITLE
chore: add rmarkdown to dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Depends: R (>= 3.1)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Imports: extrafont,
-    ggplot2
+    ggplot2,
+    rmarkdown


### PR DESCRIPTION
@ramnathv Not sure if this is the right way to add dependencies, but restoring from `renv.lock` (using `renv::restore`) fails when installing `datacamp/ggdc`, and I assume it's because all of its dependencies are not installed (cf. https://app.circleci.com/pipelines/github/datacamp-engineering/collab-and-tooling-base-images/879/workflows/4457d049-396f-4faf-8a6f-8fe6562762c8/jobs/839). It seems to be missing rmarkdown in its listed dependencies.